### PR TITLE
Catching fatal error in order to release the lock after a fatal

### DIFF
--- a/src/Command/RobustCommand.php
+++ b/src/Command/RobustCommand.php
@@ -2,11 +2,11 @@
 
 namespace Recruiter\Geezer\Command;
 
-use Exception;
 use Recruiter\Geezer\Leadership\LeadershipStrategy;
 use Recruiter\Geezer\Timing\WaitStrategy;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Throwable;
 
 interface RobustCommand
 {
@@ -30,5 +30,5 @@ interface RobustCommand
     /**
      * @return bool true on successful shutdown, false otherwhise
      */
-    public function shutdown(?Exception $e = null): bool;
+    public function shutdown(?Throwable $e = null): bool;
 }

--- a/src/Command/RobustCommandRunner.php
+++ b/src/Command/RobustCommandRunner.php
@@ -2,13 +2,13 @@
 
 namespace Recruiter\Geezer\Command;
 
-use Exception;
 use Recruiter\Geezer\Timing\WaitStrategy;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class RobustCommandRunner extends Command
 {
@@ -77,7 +77,7 @@ class RobustCommandRunner extends Command
 
             try {
                 $success = $this->wrapped->execute();
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $this->log('Thrown an Exception: ' . get_class($e), ['exception' => $e], LogLevel::ERROR);
                 $occuredException = $e;
 
@@ -94,7 +94,6 @@ class RobustCommandRunner extends Command
 
         $this->wrapped->shutdown($occuredException);
 
-        // probably not needed, ad abundantiam
         $leadershipStrategy->release();
     }
 


### PR DESCRIPTION
Fatal errors was not catched and this means that the `leadershipStrategy` was not released after a fatal.

Catching all the `Throwable` in order to improve this situation.

This PR is not backwards compatible, so a new major version should be released.